### PR TITLE
Switch to HTTPS and consolidate profiles in launchSettings

### DIFF
--- a/VirtualZoo/Properties/launchSettings.json
+++ b/VirtualZoo/Properties/launchSettings.json
@@ -4,25 +4,16 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:18545",
+      "applicationUrl": "https://localhost:44375",
       "sslPort": 44375
     }
   },
   "profiles": {
-    "http": {
+    "VirtualZoo": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "applicationUrl": "http://localhost:5285",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:7134;http://localhost:5285",
+      "applicationUrl": "https://localhost:7134",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/VirtualZooAPI/Properties/launchSettings.json
+++ b/VirtualZooAPI/Properties/launchSettings.json
@@ -4,27 +4,17 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:42315",
+      "applicationUrl": "https://localhost:44369",
       "sslPort": 44369
     }
   },
   "profiles": {
-    "http": {
+    "VirtualZooAPI": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5102",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    "https": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7016;http://localhost:5102",
+      "applicationUrl": "https://localhost:7016",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
Updated `launchSettings.json`:
- Changed application URLs from HTTP to HTTPS for `iisExpress` and profiles.
- Updated `iisExpress` settings to use HTTPS URLs with new ports.
- Consolidated profiles `http` and `https` into `VirtualZoo` and `VirtualZooAPI`.
- Updated `applicationUrl` for profiles to use only HTTPS URLs.
- Removed redundant `http` profile settings.
- Kept `launchUrl` for `VirtualZooAPI` profile set to "swagger".