### PR TITLE
Add feedback for no redistribution needed

### DIFF
--- a/VirtualZooAPI/Services/Implementations/ZooService.cs
+++ b/VirtualZooAPI/Services/Implementations/ZooService.cs
@@ -105,6 +105,12 @@ namespace VirtualZooAPI.Services.Implementations
                 await _animalService.UpdateAnimalAsync(animal);
             }
 
+            // Als alle animals een verblijf hebben dat voldoet aan de eisen, is er geen herverdeling nodig
+            if (!feedback.Any())
+            {
+                feedback.Add("Alle dieren zitten al in een geschikt verblijf. Er was geen herverdeling nodig.");
+            }
+
             return feedback;
         }
 


### PR DESCRIPTION
Added a check to determine if all animals already have suitable enclosures. If so, a feedback message is added indicating that no redistribution was necessary. This ensures users are informed when no changes are required.