### PR TITLE
Update ApiClient base URL and add value to checkbox input

### DIFF
--- a/VirtualZoo/Program.cs
+++ b/VirtualZoo/Program.cs
@@ -26,7 +26,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
 // Add HttpClient for API calls
 builder.Services.AddHttpClient("ApiClient", client =>
 {
-    client.BaseAddress = new Uri("https://localhost:7134/");
+    client.BaseAddress = new Uri("https://localhost:7016/");
 });
 
 var app = builder.Build();

--- a/VirtualZoo/Views/Zoo/ConfirmAutoAssign.cshtml
+++ b/VirtualZoo/Views/Zoo/ConfirmAutoAssign.cshtml
@@ -8,7 +8,7 @@
     <p>Confirm your intensions regarding autoassign:</p>
     
     <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="resetExisting" name="resetExisting" />
+        <input class="form-check-input" type="checkbox" id="resetExisting" name="resetExisting" value="true" />
         <label class="form-check-label" for="resetExisting">
             Discard all existing enclosures, auto-create new ones.
         </label>


### PR DESCRIPTION
Changed the BaseAddress for the HttpClient named "ApiClient" from https://localhost:7134/ to https://localhost:7016/ in Program.cs. Added a value attribute set to "true" for the checkbox input with id and name "resetExisting" in ConfirmAutoAssign.cshtml to ensure correct form submission.